### PR TITLE
added mullvad.net as VPN-Provider

### DIFF
--- a/Mullvad/LOCATIONS.txt
+++ b/Mullvad/LOCATIONS.txt
@@ -1,0 +1,88 @@
+Australia - Sydney (UDP),au.mullvad.net,udp,1194
+Australia - Sydney (TCP),au.mullvad.net,tcp-client,443
+Australia - Melbourne (UDP),au-mel.mullvad.net,udp,1194
+Australia - Melbourne (TCP),au-mel.mullvad.net,tcp-client,443
+Austria - Wien (UDP),at.mullvad.net,udp,1194
+Austria - Wien (TCP),at.mullvad.net,tcp-client,443
+Belgium - Brussels (UDP),be.mullvad.net,udp,1194
+Belgium - Brussels (TCP),be.mullvad.net,tcp-client,443
+Bulgaria - Sofia (UDP),bg.mullvad.net,udp,1194
+Bulgaria - Sofia (TCP),bg.mullvad.net,tcp-client,443
+Canada - Toronto (UDP),ca-on.mullvad.net,udp,1194
+Canada - Toronto (TCP),ca-on.mullvad.net,tcp-client,443
+Canada - Vancouver (UDP),ca-bc.mullvad.net,udp,1194
+Canada - Vancouver (TCP),ca-bc.mullvad.net,tcp-client,443
+Czech Rep. - Prague (UDP),cz.mullvad.net,udp,1194
+Czech Rep. - Prague (TCP),cz.mullvad.net,tcp-client,443
+Denmark - Copenhagen (UDP),dk.mullvad.net,udp,1194
+Denmark - Copenhagen (TCP),dk.mullvad.net,tcp-client,443
+Finland - Helsinki (UDP),fi.mullvad.net,udp,1194
+Finland - Helsinki (TCP),fi.mullvad.net,tcp-client,443
+France - Paris (UDP),fr.mullvad.net,udp,1194
+France - Paris (TCP),fr.mullvad.net,tcp-client,443
+Germany - Berlin (UDP),de-ber.mullvad.net,udp,1194
+Germany - Berlin (TCP),de-ber.mullvad.net,tcp-client,443
+Germany - Frankfurt (UDP),de-fra.mullvad.net,udp,1194
+Germany - Frankfurt (TCP),de-fra.mullvad.net,tcp-client,443
+Hong Kong (UDP),hk.mullvad.net,udp,1194
+Hong Kong (TCP),hk.mullvad.net,tcp-client,443
+Hungary - Budapest (UDP),hu.mullvad.net,udp,1194
+Hungary - Budapest (TCP),hu.mullvad.net,tcp-client,443
+Israel - Petach-Tikva (UDP),il.mullvad.net,udp,1194
+Israel - Petach-Tikva (TCP),il.mullvad.net,tcp-client,443
+Italy - Milan (UDP),it.mullvad.net,udp,1194
+Italy - Milan (UDP),it.mullvad.net,tcp-client,443
+Japan - Tokyo (UDP),jp.mullvad.net,udp,1194
+Japan - Tokyo (TCP),jp.mullvad.net,tcp-client,443
+Moldova - Chisinau (UDP),md.mullvad.net,udp,1194
+Moldova - Chisinau (TCP),md.mullvad.net,tcp-client,443
+Netherlands - Amsterdam (UDP),nl.mullvad.net,udp,1194
+Netherlands - Amsterdam (TCP),nl.mullvad.net,tcp-client,443
+Norway - Oslo (UDP),no.mullvad.net,udp,1194
+Norway - Oslo (TCP),no.mullvad.net,tcp-client,443
+Poland - Warsaw (UDP),pl.mullvad.net,udp,1194
+Poland - Warsaw (TCP),pl.mullvad.net,tcp-client,443
+Portugal - Lisbon (UDP),pt.mullvad.net,udp,1194
+Portugal - Lisbon (TCP),pt.mullvad.net,tcp-client,443
+Romania - Bucharest (UDP),ro.mullvad.net,udp,1194
+Romania - Bucharest (TCP),ro.mullvad.net,tcp-client,443
+Singapore (UDP),sg.mullvad.net,udp,1194
+Singapore (TCP),sg.mullvad.net,tcp-client,443
+Spain - Madrid (UDP),es.mullvad.net,udp,1194
+Spain - Madrid (TCP),es.mullvad.net,tcp-client,443
+Sweden - Malmö (UDP),se-mma.mullvad.net,udp,1194
+Sweden - Malmö (TCP),se-mma.mullvad.net,tcp-client,443
+Sweden - Helsingborg (UDP),se-sto.mullvad.net,udp,1194
+Sweden - Helsingborg (TCP),se-sto.mullvad.net,tcp-client,443
+Sweden - Stockholm (UDP),se-sto.mullvad.net,udp,1194
+Sweden - Stockholm (TCP),se-sto.mullvad.net,tcp-client,443
+Switzerland - Zurich (UDP),ch.mullvad.net,udp,1194
+Switzerland - Zurich (TCP),ch.mullvad.net,tcp-client,443
+UK - London (UDP),gb-lon.mullvad.net,udp,1194
+UK - London (TCP),gb-lon.mullvad.net,tcp-client,443
+UK - Manchester (UDP),gb-mnc.mullvad.net,udp,1194
+UK - Manchester (TCP),gb-mnc.mullvad.net,tcp-client,443
+USA - Atlanta (UDP),us-ga.mullvad.net,udp,1194
+USA - Atlanta (TCP),us-ga.mullvad.net,tcp-client,443
+USA - Chicago (UDP),us-il.mullvad.net,udp,1194
+USA - Chicago (TCP),us-il.mullvad.net,tcp-client,443
+USA - Dallas (UDP),s-tx.mullvad.net,udp,1194
+USA - Dallas (TCP),s-tx.mullvad.net,tcp-client,443
+USA - Las Vegas (UDP),us-nv.mullvad.net,udp,1194
+USA - Las Vegas (TCP),us-nv.mullvad.net,tcp-client,443
+USA - Los Angeles (UDP),us-ca.mullvad.net,udp,1194
+USA - Los Angeles (TCP),us-ca.mullvad.net,tcp-client,443
+USA - Miami (UDP),us-fl.mullvad.net,udp,1194
+USA - Miami (TCP),us-fl.mullvad.net,tcp-client,443
+USA - Newark (UDP),us-nj.mullvad.net,udp,1194
+USA - Newark (TCP),us-nj.mullvad.net,tcp-client,443
+USA - New Jersey (UDP),us-nj.mullvad.net,udp,1194
+USA - New Jersey (TCP),us-nj.mullvad.net,tcp-client,443
+USA - New York (UDP),us-ny.mullvad.net,udp,1194
+USA - New York (TCP),us-ny.mullvad.net,tcp-client,443
+USA - Phoenix (UDP),us-az.mullvad.net,udp,1194
+USA - Phoenix (TCP),us-az.mullvad.net,tcp-client,443
+USA - Salt Lake City (UDP),us-ut.mullvad.net,udp,1194
+USA - Salt Lake City (TCP),us-ut.mullvad.net,tcp-client,443
+USA - Seattle (UDP),us-wa.mullvad.net,udp,1194
+USA - Seattle (TCP),us-wa.mullvad.net,tcp-client,443

--- a/Mullvad/METADATA.txt
+++ b/Mullvad/METADATA.txt
@@ -1,0 +1,3 @@
+LOCATIONS.txt
+TEMPLATE.txt
+ca.crt

--- a/Mullvad/TEMPLATE.txt
+++ b/Mullvad/TEMPLATE.txt
@@ -1,0 +1,20 @@
+client
+dev tun
+proto #PROTO
+remote #SERVER #PORT
+cipher AES-256-CBC
+resolv-retry infinite
+nobind
+persist-key
+persist-tun
+comp-lzo
+verb 3
+remote-cert-tls server
+ping 10
+ping-restart 60
+auth-user-pass #PASS
+reneg-sec 0
+tun-ipv6
+ca #CERT
+tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA:TLS-DHE-RSA-WITH-AES-128-CBC-SHA
+

--- a/Mullvad/ca.crt
+++ b/Mullvad/ca.crt
@@ -1,0 +1,109 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=NA, ST=None, L=None, O=Mullvad, CN=Mullvad CA/emailAddress=info@mullvad.net
+        Validity
+            Not Before: Mar 24 16:19:48 2009 GMT
+            Not After : Mar 22 16:19:48 2019 GMT
+        Subject: C=NA, ST=None, L=None, O=Mullvad, CN=master.mullvad.net/emailAddress=info@mullvad.net
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+            RSA Public Key: (2048 bit)
+                Modulus (2048 bit):
+                    00:c5:00:39:5d:fe:9b:0c:b7:ff:76:a4:93:bf:26:
+                    1b:d6:c8:4a:e5:3c:ce:1c:2c:16:80:a2:61:a6:e9:
+                    63:4b:70:a1:80:6f:0e:0c:bb:a9:b6:d1:bd:f5:a0:
+                    78:82:09:4d:94:22:aa:77:7c:09:36:42:cd:a5:a6:
+                    90:73:27:42:00:31:e4:d4:8b:49:36:65:a3:25:82:
+                    b8:26:d7:d1:f5:b5:a9:be:57:93:9d:7c:d6:1c:df:
+                    9a:87:81:53:0b:17:81:d1:0d:ca:dc:4d:19:13:fa:
+                    11:e6:da:68:eb:81:05:39:e3:1e:3a:3f:fc:e2:64:
+                    3c:98:3c:89:a9:42:b3:30:70:57:56:a1:f5:08:b2:
+                    75:12:a0:36:93:9d:69:e9:7e:11:71:d9:1c:e8:7d:
+                    ec:03:21:11:7a:0a:7a:03:35:ba:b8:b2:0c:3a:6f:
+                    57:88:62:45:3d:0c:6c:18:ff:21:49:37:ae:40:78:
+                    6d:45:52:29:ac:21:ad:4a:01:61:67:0b:01:c4:ac:
+                    b0:88:97:52:ff:cb:3a:21:f0:14:2b:c1:79:8d:79:
+                    35:14:fc:9c:3f:6c:c9:62:fc:8c:c7:a8:51:34:75:
+                    1c:23:d5:db:b9:44:08:1c:0c:17:2c:21:2a:b4:29:
+                    db:15:59:e7:a9:1c:d6:19:19:ef:e4:6b:ea:78:6d:
+                    76:8d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                75:8A:14:92:0D:F3:6E:B7:36:4F:8B:4F:15:6C:3F:18:15:90:64:DE
+            X509v3 Authority Key Identifier: 
+                keyid:E1:63:B4:3E:55:A3:D2:37:5F:DE:3A:91:48:51:4B:20:1A:F2:9B:C5
+                DirName:/C=NA/ST=None/L=None/O=Mullvad/CN=Mullvad CA/emailAddress=info@mullvad.net
+                serial:84:68:2E:A0:51:2A:BB:D4
+
+            X509v3 Basic Constraints: 
+                CA:TRUE
+    Signature Algorithm: sha1WithRSAEncryption
+        a4:b4:62:3d:cb:7e:57:b3:bd:2a:41:e0:3b:94:d0:4c:08:69:
+        8a:b1:73:15:13:20:c9:d7:b0:b6:5d:65:4a:4d:1d:27:cc:ca:
+        11:0e:86:fa:65:61:26:39:c2:54:8e:da:eb:78:21:37:0e:c7:
+        a4:d2:17:8a:4b:ad:17:84:25:5e:24:0e:9a:81:ff:d1:1b:0e:
+        32:9b:f4:81:e0:07:e9:8f:9d:c1:43:7f:40:30:01:07:7c:02:
+        c7:c4:9c:05:48:4c:bf:41:69:57:c1:d3:bb:a3:5a:01:17:96:
+        b0:c9:00:22:57:2f:84:da:45:33:6e:6c:2b:13:c5:af:75:a7:
+        b2:6b:71:6e:13:2c:97:0e:d9:93:da:6d:d9:34:c6:06:7d:0e:
+        e2:b8:d2:78:13:79:0f:ac:ac:a8:68:a9:72:73:7a:d8:ab:7b:
+        0a:b0:54:b5:f3:ce:29:0d:47:82:0c:b4:d9:20:64:ff:ef:17:
+        46:92:de:65:e8:67:ce:3a:92:de:e4:3e:99:73:9f:7a:7c:00:
+        72:07:39:78:77:37:62:89:a2:db:24:fd:60:2a:e0:82:57:f6:
+        55:94:f6:79:47:19:c9:13:3b:5d:b7:6b:66:14:d4:7d:3c:76:
+        75:e9:a3:55:ba:b4:92:30:3b:ad:66:72:0c:39:4b:cc:95:a9:
+        bc:06:ef:2b
+-----BEGIN CERTIFICATE-----
+MIIEQjCCAyqgAwIBAgIBAzANBgkqhkiG9w0BAQUFADBzMQswCQYDVQQGEwJOQTEN
+MAsGA1UECBMETm9uZTENMAsGA1UEBxMETm9uZTEQMA4GA1UEChMHTXVsbHZhZDET
+MBEGA1UEAxMKTXVsbHZhZCBDQTEfMB0GCSqGSIb3DQEJARYQaW5mb0BtdWxsdmFk
+Lm5ldDAeFw0wOTAzMjQxNjE5NDhaFw0xOTAzMjIxNjE5NDhaMHsxCzAJBgNVBAYT
+Ak5BMQ0wCwYDVQQIEwROb25lMQ0wCwYDVQQHEwROb25lMRAwDgYDVQQKEwdNdWxs
+dmFkMRswGQYDVQQDExJtYXN0ZXIubXVsbHZhZC5uZXQxHzAdBgkqhkiG9w0BCQEW
+EGluZm9AbXVsbHZhZC5uZXQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+AQDFADld/psMt/92pJO/JhvWyErlPM4cLBaAomGm6WNLcKGAbw4Mu6m20b31oHiC
+CU2UIqp3fAk2Qs2lppBzJ0IAMeTUi0k2ZaMlgrgm19H1tam+V5OdfNYc35qHgVML
+F4HRDcrcTRkT+hHm2mjrgQU54x46P/ziZDyYPImpQrMwcFdWofUIsnUSoDaTnWnp
+fhFx2RzofewDIRF6CnoDNbq4sgw6b1eIYkU9DGwY/yFJN65AeG1FUimsIa1KAWFn
+CwHErLCIl1L/yzoh8BQrwXmNeTUU/Jw/bMli/IzHqFE0dRwj1du5RAgcDBcsISq0
+KdsVWeepHNYZGe/ka+p4bXaNAgMBAAGjgdgwgdUwHQYDVR0OBBYEFHWKFJIN8263
+Nk+LTxVsPxgVkGTeMIGlBgNVHSMEgZ0wgZqAFOFjtD5Vo9I3X946kUhRSyAa8pvF
+oXekdTBzMQswCQYDVQQGEwJOQTENMAsGA1UECBMETm9uZTENMAsGA1UEBxMETm9u
+ZTEQMA4GA1UEChMHTXVsbHZhZDETMBEGA1UEAxMKTXVsbHZhZCBDQTEfMB0GCSqG
+SIb3DQEJARYQaW5mb0BtdWxsdmFkLm5ldIIJAIRoLqBRKrvUMAwGA1UdEwQFMAMB
+Af8wDQYJKoZIhvcNAQEFBQADggEBAKS0Yj3LflezvSpB4DuU0EwIaYqxcxUTIMnX
+sLZdZUpNHSfMyhEOhvplYSY5wlSO2ut4ITcOx6TSF4pLrReEJV4kDpqB/9EbDjKb
+9IHgB+mPncFDf0AwAQd8AsfEnAVITL9BaVfB07ujWgEXlrDJACJXL4TaRTNubCsT
+xa91p7JrcW4TLJcO2ZPabdk0xgZ9DuK40ngTeQ+srKhoqXJzetirewqwVLXzzikN
+R4IMtNkgZP/vF0aS3mXoZ846kt7kPplzn3p8AHIHOXh3N2KJotsk/WAq4IJX9lWU
+9nlHGckTO123a2YU1H08dnXpo1W6tJIwO61mcgw5S8yVqbwG7ys=
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIEQjCCAyqgAwIBAgIJAIRoLqBRKrvUMA0GCSqGSIb3DQEBBQUAMHMxCzAJBgNV
+BAYTAk5BMQ0wCwYDVQQIEwROb25lMQ0wCwYDVQQHEwROb25lMRAwDgYDVQQKEwdN
+dWxsdmFkMRMwEQYDVQQDEwpNdWxsdmFkIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZv
+QG11bGx2YWQubmV0MB4XDTA5MDMyNDA2NDcyNVoXDTE5MDMyMjA2NDcyNVowczEL
+MAkGA1UEBhMCTkExDTALBgNVBAgTBE5vbmUxDTALBgNVBAcTBE5vbmUxEDAOBgNV
+BAoTB011bGx2YWQxEzARBgNVBAMTCk11bGx2YWQgQ0ExHzAdBgkqhkiG9w0BCQEW
+EGluZm9AbXVsbHZhZC5uZXQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+AQDNNzZOrq+gMaA6wfyWdNFmxlM2OB1czwFgtPiDd9f6F8m6CGYBQog3Q2Wx3yAv
+hxt/uchFBCKtYz6Yh59BCxXKfNAQT2uaMC6KAvKFgz0wppi4S8YbWg2KDelNO/Zv
+Rb1QT4CBWMbtYzCQZvlJpHr2ZwuXG2OiT477oMyX5Hmf+iT0drmqi+wylRr7CRBs
+LBu+fxLZ2LFD5g6MATuL3ql5JLIoVjlSqIgbld74pD4WUnM61HRwFsKoCEjq409Y
+QNP1xO7BeaJu3uQvg/HJhXnGZxTatXhqvdCuAPQRppQ4UnkUzxdSTrfgM3hqMony
+vX1vy0dX1S8iTQCIeyzAYNObAgMBAAGjgdgwgdUwHQYDVR0OBBYEFOFjtD5Vo9I3
+X946kUhRSyAa8pvFMIGlBgNVHSMEgZ0wgZqAFOFjtD5Vo9I3X946kUhRSyAa8pvF
+oXekdTBzMQswCQYDVQQGEwJOQTENMAsGA1UECBMETm9uZTENMAsGA1UEBxMETm9u
+ZTEQMA4GA1UEChMHTXVsbHZhZDETMBEGA1UEAxMKTXVsbHZhZCBDQTEfMB0GCSqG
+SIb3DQEJARYQaW5mb0BtdWxsdmFkLm5ldIIJAIRoLqBRKrvUMAwGA1UdEwQFMAMB
+Af8wDQYJKoZIhvcNAQEFBQADggEBAMjMAFPDeFOrQsvMXD/x+CuARwegS2PDZuB5
+f1Svw3YDF6cB1jlc0F12nh9SZxaYRwKIlpYoolLCOLoUCLwQJ0gsokxLV7G4gVb8
+dzETnNq4HG/QOPwPisjoOCaEmcd0tx1EkyNY0KLqFZTS0VdmDHCn89dDFA/6yuYI
+5u04uJs7c/K4qaW7X6ajOOdneqjbtPeVOvx9DWXHxA0xz4Y+/w4laX/OTRD7jySq
+K9fLfRliE5zsxzpUr5EWxAnqiABoWL71SiItk5fG8k3MJJ9SVr+YnTHmE7S4KNqu
+4wTksvkb0Tmjae1lRSlMd6u2AulAxVcVKAod2QVffhj+hdkYM94=
+-----END CERTIFICATE-----


### PR DESCRIPTION
I tried to add mullvad.net as VPN-Provider. The only thing I couldn't figure out are the two numbers at the beginning of the METADATA.txt. 