### PR TITLE
Removing comp-lzo

### DIFF
--- a/CyberGhost/TEMPLATE.txt
+++ b/CyberGhost/TEMPLATE.txt
@@ -17,7 +17,6 @@ route-delay 5
 #REMOVE1fragment 1300
 #REMOVE1mssfix 1300
 verb 4
-comp-lzo
 ca #CERT
 cert #USERCERT
 key #USERKEY


### PR DESCRIPTION
Removing the comp-lzo option.
Please approve the change.
Thank you,
Cristiana G, Cyberghost Team