### PR TITLE
Adding Colombia to PIA provider locations

### DIFF
--- a/PIA/LOCATIONS Default Encryption.txt
+++ b/PIA/LOCATIONS Default Encryption.txt
@@ -38,6 +38,8 @@ CA Vancouver (UDP),ca-vancouver.privacy.network,udp,1198,#REMOVE=1 #CERT=ca.rsa.
 CA Vancouver (TCP),ca-vancouver.privacy.network,tcp,502,#REMOVE=1 #CERT=ca.rsa.2048.crt #CRLVERIFY=crl.rsa.2048.pem
 China (UDP),china.privacy.network,udp,1198,#REMOVE=1 #CERT=ca.rsa.2048.crt #CRLVERIFY=crl.rsa.2048.pem
 China (TCP),china.privacy.network,tcp,502,#REMOVE=1 #CERT=ca.rsa.2048.crt #CRLVERIFY=crl.rsa.2048.pem
+Colombia (UDP),bogota.privacy.network,udp,1198,#REMOVE=1 #CERT=ca.rsa.2048.crt #CRLVERIFY=crl.rsa.2048.pem
+Colombia (TCP),bogota.privacy.network,tcp,502,#REMOVE=1 #CERT=ca.rsa.2048.crt #CRLVERIFY=crl.rsa.2048.pem
 Cyprus (UDP),cyprus.privacy.network,udp,1198,#REMOVE=1 #CERT=ca.rsa.2048.crt #CRLVERIFY=crl.rsa.2048.pem
 Cyprus (TCP),cyprus.privacy.network,tcp,502,#REMOVE=1 #CERT=ca.rsa.2048.crt #CRLVERIFY=crl.rsa.2048.pem
 Czech Republic (UDP),czech.privacy.network,udp,1198,#REMOVE=1 #CERT=ca.rsa.2048.crt #CRLVERIFY=crl.rsa.2048.pem

--- a/PIA/LOCATIONS Strong Encryption.txt
+++ b/PIA/LOCATIONS Strong Encryption.txt
@@ -38,6 +38,8 @@ CA Vancouver (UDP),ca-vancouver.privacy.network,udp,1197,#REMOVE=2 #CERT=ca.rsa.
 CA Vancouver (TCP),ca-vancouver.privacy.network,tcp,501,#REMOVE=2 #CERT=ca.rsa.4096.crt #CRLVERIFY=crl.rsa.4096.pem
 China (UDP),china.privacy.network,udp,1197,#REMOVE=2 #CERT=ca.rsa.4096.crt #CRLVERIFY=crl.rsa.4096.pem
 China (TCP),china.privacy.network,tcp,501,#REMOVE=2 #CERT=ca.rsa.4096.crt #CRLVERIFY=crl.rsa.4096.pem
+Colombia (UDP),bogota.privacy.network,udp,1197,#REMOVE=2 #CERT=ca.rsa.4096.crt #CRLVERIFY=crl.rsa.4096.pem
+Colombia (TCP),bogota.privacy.network,tcp,501,#REMOVE=2 #CERT=ca.rsa.4096.crt #CRLVERIFY=crl.rsa.4096.pem
 Cyprus (UDP),cyprus.privacy.network,udp,1197,#REMOVE=2 #CERT=ca.rsa.4096.crt #CRLVERIFY=crl.rsa.4096.pem
 Cyprus (TCP),cyprus.privacy.network,tcp,501,#REMOVE=2 #CERT=ca.rsa.4096.crt #CRLVERIFY=crl.rsa.4096.pem
 Czech Republic (UDP),czech.privacy.network,udp,1197,#REMOVE=2 #CERT=ca.rsa.4096.crt #CRLVERIFY=crl.rsa.4096.pem


### PR DESCRIPTION
The downloaded files in this article https://helpdesk.privateinternetaccess.com/kb/articles/where-can-i-find-your-ovpn-files seem to be outdated because the list of supported servers supported by PIA is larger, see https://serverlist.piaservers.net/vpninfo/servers/v6

Following this article (https://helpdesk.privateinternetaccess.com/kb/articles/ccp-openvpn-configuration-generator), when generating the *.ovpn files for `AES-128-CBC` (UDP and TCP) and `AES-256-CBC` (UDP and TCP), the obtained certificates are the same as the ones in the current repository.